### PR TITLE
Add R dependencies

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -5,6 +5,13 @@ Version: 0.1.0
 Author: Oleh Prylutskyi
 Maintainer: Oleh Prylutskyi <oleh.prylutskyi@gmail.com>
 Description: This package is aimed to obtain, process, and visualize spectral reflectance data for the user-defined land(water) surface classes, for visual exploring in which wavelength the classes differ. Input should be a shapefile with polygons of surface classes (it might be different habitat types, crops, any other things). The single source of spectral data are Sentinel2 L2A satellite mission optical bands pixel data so far, obtained through Google Earth Engine service.
+Depends: R (>= 4.1.2)
+Imports:
+    rgee (>= 1.1.3),
+    geojsonio (>= 0.9.4),
+    sf (>= 1.0-7),
+    tidyverse (>= 1.3.1),
+    ggplot2 (>= 3.3.5)
 License: GNU General Public License v3.0
 Encoding: UTF-8
 LazyData: true


### PR DESCRIPTION
This PR adds dependencies, which would be installed along with `spectralR`.
- `rgee` >= 1.1.3
-  `geojsonio` >= 0.9.4
-  `sf` >= 1.0-7
-  `tidyverse` >= 1.3.1
-  `ggplot2` >= 3.3.5